### PR TITLE
fix `a-assoc-1` vs slot 0 of vectors

### DIFF
--- a/a.el
+++ b/a.el
@@ -128,7 +128,7 @@ Internal helper function."
       (cons (cons k v) coll)))
 
    ((vectorp coll)
-    (if (and (integerp k) (> k 0))
+    (if (and (integerp k) (>= k 0))
         (if (< k (length coll))
             (let ((copy (copy-sequence coll)))
               (aset copy k v)

--- a/test/a-test.el
+++ b/test/a-test.el
@@ -81,6 +81,7 @@
                           :foo :bar
                           :baz :baq) '((:baz . :baq) (:foo . :bar))))
 
+  (should (equal (a-assoc [1 2 3] 0 :foo) [:foo 2 3]))
   (should (equal (a-assoc [1 2 3] 1 :foo) [1 :foo 3]))
   (should (equal (a-assoc [1 2 3] 5 :foo) [1 2 3 nil nil :foo]))
   (should-error (a-assoc '() :foo))


### PR DESCRIPTION
`a-assoc-1` would silently return `nil` when asked to update slot 0 in
a vector, due to an incorrect edge condition check.

This fixes the bug, and adds a test to show it is resolved.  The bug
manifested in `a-assoc` and related function.